### PR TITLE
Add URL package header

### DIFF
--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -5,6 +5,7 @@
 
 ;; Author: Joren Van Onder <joren.vanonder@gmail.com>
 ;; Maintainer: Joren Van Onder <joren.vanonder@gmail.com>
+;; URL: https://github.com/jorenvo/simple-mpc
 ;; Keywords: multimedia, mpd, mpc
 ;; Version: 1.0
 ;; Package-Requires: ((s "1.10.0"))


### PR DESCRIPTION
Emacs can recognize and make use of it, for example, 'C-h P simple-mpc' will display this URL as homepage.