### PR TITLE
Better display current track in the current playlist view

### DIFF
--- a/simple-mpc-current-playlist.el
+++ b/simple-mpc-current-playlist.el
@@ -68,6 +68,11 @@ position. Otherwise, move it to the current track in the playlist."
         (insert
          (simple-mpc-format-as-table (simple-mpc-call-mpc-string
                                       (append (list "--format" (simple-mpc-get-playlist-format)) '("playlist")))))
+        (save-excursion
+          (simple-mpc-goto-line (simple-mpc-get-current-playlist-position))
+          (put-text-property
+           (line-beginning-position) (line-end-position)
+           'face 'simple-mpc-current-track-face))
         (if keep-point
             (progn
               (simple-mpc-goto-line original-line)

--- a/simple-mpc-vars.el
+++ b/simple-mpc-vars.el
@@ -90,5 +90,10 @@ characters in GNU Emacs by pressing C-q <TAB>."
   "For the different headers in the main view."
   :group 'simple-mpc)
 
+(defface simple-mpc-current-track-face
+  '((t :inherit font-lock-keyword-face :bold t))
+  "For the current track in the current playlist view."
+  :group 'simple-mpc)
+
 (provide 'simple-mpc-vars)
 ;;; simple-mpc-vars.el ends here

--- a/simple-mpc-vars.el
+++ b/simple-mpc-vars.el
@@ -40,7 +40,8 @@
 
 (defcustom simple-mpc-playlist-format ""
   "Format string that will be given to mpc through --format."
-  :group 'simple-mpc)
+  :group 'simple-mpc
+  :type 'string)
 
 (defcustom simple-mpc-seek-time-in-s 5
   "The time in seconds that will be used to do relative seeking


### PR DESCRIPTION
This commit add a new customizable face called `simple-mpc-current-track-face`, which inherit the default `font-lock-keyword-face` and boldify it. The font property works on simple list or table view.

Also this PR remove a little warning while byte-compiling `simple-mpc-vars.el`.