### PR TITLE
Changed s-match to pcase with rx

### DIFF
--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -9,7 +9,6 @@
 ;; URL: https://github.com/jorenvo/simple-mpc
 ;; Keywords: multimedia, mpd, mpc
 ;; Version: 1.0
-;; Package-Requires: ((s "1.10.0"))
 
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
2021-04-05  Valeriy Litkovskyy  <vlr.ltkvsk@protonmail.com>

    * simple-mpc-query.el (simple-mpc-query-build-result-alist):
    Changed s-match to pcase with rx form.  Dropped s dependency.
    Added compilation-time dependencies: rx, pcase.

First of all, thank you! This is a fantastic package. Just what I wanted. I was so frustrated with mingus and mpdel. You are my saviour :)

Back to the point. Since you used **only** `s-match` from _s_ and used it **only** once, I thought it would be better to drop `s` dependency and replace it with a (better?) builti-in alternative.

I highly recommend using `rx` macro, especially for complex regexps. Also, `pcase` has a convenient extension for `rx` to make references with `let` to the parts of a string. Nice!
