### PR TITLE
Add repeat mode toggle

### DIFF
--- a/simple-mpc-mode.el
+++ b/simple-mpc-mode.el
@@ -36,6 +36,7 @@
     (define-key map "b" 'simple-mpc-seek-backward)
     (define-key map "V" 'simple-mpc-increase-volume)
     (define-key map "v" 'simple-mpc-decrease-volume)
+    (define-key map "r" 'simple-mpc-toggle-repeat)
     (define-key map "c" 'simple-mpc-view-current-playlist)  ;; autoload this
     (define-key map "C" 'simple-mpc-clear-current-playlist)
     (define-key map "S" 'simple-mpc-shuffle-current-playlist)

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2015,2016 Joren Van Onder <joren@jvo.sh>
 ;; Copyright (C) 2016 Andriy Kmit' <dev@madand.net>
 ;; Copyright (C) 2020 Sean Farley <sean@farley.io>
+;; Copyright (C) 2022 Joseph Turner <joseph@breatheoutbreathe.in>
 
 ;; Author: Joren Van Onder <joren@jvo.sh>
 ;; Maintainer: Joren Van Onder <joren@jvo.sh>
@@ -104,6 +105,12 @@
   (message "%s" "Cleared current playlist.")
   (simple-mpc-maybe-refresh-playlist))
 
+(defun simple-mpc-toggle-repeat ()
+  "Toggle repeat mode."
+  (interactive)
+  (simple-mpc-call-mpc nil "repeat")
+  (message "%s" "Toggled repeat mode."))
+
 (defun simple-mpc-shuffle-current-playlist ()
   "Shuffle the current playlist."
   (interactive)
@@ -143,6 +150,7 @@ IGNORE-AUTO and NOCONFIRM are passed by `revert-buffer'."
               "      * seek [b]ackward\n"
               "      * increase [V]olume\n"
               "      * decrease [v]olume\n"
+              "      * toggle [r]epeat mode\n"
               (propertize "\n   * playlist\n" 'face 'simple-mpc-main-headers)
               "      * view [c]urrent playlist\n"
               "      * [C]lear current playlist\n"


### PR DESCRIPTION
This feature would be improved if the message read "Repeat mode on" or "Repeat mode off". I think we'd want to parse the output of the `mpc` command, which reveals the state of repeat mode.

I'm not sure the best way to do that (or even if you consider that to be within the scope of `simple-mpc`). Thank you!