### PR TITLE
Echo relevant info from `mpc status` in interactive simple-mpc* functions

### DIFF
--- a/simple-mpc-current-playlist.el
+++ b/simple-mpc-current-playlist.el
@@ -71,24 +71,27 @@ IGNORE-AUTO and NOCONFIRM are passed by `revert-buffer'."
         (insert
          (simple-mpc-format-as-table (simple-mpc-call-mpc-string
                                       (append (list "--format" (simple-mpc-get-playlist-format)) '("playlist")))))
-        (save-excursion
-          (simple-mpc-goto-line (simple-mpc-get-current-playlist-position))
-          (put-text-property
-           (line-beginning-position) (line-end-position)
-           'face 'simple-mpc-current-track-face))
-        (if keep-point
-            (progn
-              (simple-mpc-goto-line original-line)
-              (move-to-column original-column)
-              (set-window-start nil window-start t)
-              (set-window-hscroll nil window-hscroll))
-          (simple-mpc-goto-line (simple-mpc-get-current-playlist-position)))
-        (switch-to-buffer buf)
-        (simple-mpc-mode)
-        (simple-mpc-current-playlist-mode)
-        (hl-line-mode)
-        (when simple-mpc-playlist-auto-refresh
-          (simple-mpc-playlist-refresh-timer-start))))))
+        (let ((playlist-position 0))
+          (when (simple-mpc-extract-status 'playlist-position)
+            (setq playlist-position (string-to-number (simple-mpc-extract-status 'playlist-position))))
+          (save-excursion
+            (simple-mpc-goto-line playlist-position)
+            (put-text-property
+             (line-beginning-position) (line-end-position)
+             'face 'simple-mpc-current-track-face))
+          (if keep-point
+              (progn
+                (simple-mpc-goto-line original-line)
+                (move-to-column original-column)
+                (set-window-start nil window-start t)
+                (set-window-hscroll nil window-hscroll))
+            (simple-mpc-goto-line playlist-position))
+          (switch-to-buffer buf)
+          (simple-mpc-mode)
+          (simple-mpc-current-playlist-mode)
+          (hl-line-mode)
+          (when simple-mpc-playlist-auto-refresh
+            (simple-mpc-playlist-refresh-timer-start)))))))
 
 (defun simple-mpc-play-current-line ()
   "Plays the song on the current line."

--- a/simple-mpc-mode.el
+++ b/simple-mpc-mode.el
@@ -1,6 +1,7 @@
 ;;; simple-mpc-mode.el --- part of simple-mpc
 ;;
 ;; Copyright (C) 2015,2016 Joren Van Onder <joren@jvo.sh>
+;; Copyright (C) 2022 Joseph Turner <joseph@breatheoutbreathe.in>
 
 ;; Author: Joren Van Onder <joren@jvo.sh>
 ;; URL: https://github.com/jorenvo/simple-mpc

--- a/simple-mpc-query.el
+++ b/simple-mpc-query.el
@@ -114,7 +114,9 @@ SEARCH-TYPE is a tag type, SEARCH-QUERY is the actual query."
 When a region is active, add all the songs in the region to the
 current playlist. When PLAY is non-nil, immediately play them."
   (interactive)
-  (let ((current-amount-in-playlist (simple-mpc-get-amount-of-songs-in-playlist)))
+  (let ((playlist-length 0))
+    (when (simple-mpc-extract-status 'playlist-length)
+      (setq playlist-length (string-to-number (simple-mpc-extract-status 'playlist-length))))
     (if (use-region-p)
         (let ((first-line-region (line-number-at-pos (region-beginning)))
               (last-line-region (if (eq (region-end) (point-max))
@@ -137,7 +139,7 @@ current playlist. When PLAY is non-nil, immediately play them."
                                             (buffer-substring-no-properties (line-beginning-position) (line-end-position)))))
       (forward-line))
     (if play
-        (simple-mpc-call-mpc nil (list "play" (number-to-string (1+ current-amount-in-playlist)))))))
+        (simple-mpc-call-mpc nil (list "play" (number-to-string (1+ playlist-length)))))))
 
 (defun simple-mpc-query-sort (&optional reverse)
   "Sort all query results alphabetically.

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -100,12 +100,6 @@ output as a string."
     (simple-mpc-call-mpc t mpc-args)
     (buffer-string)))
 
-(defun simple-mpc-get-amount-of-songs-in-playlist ()
-  "Return the number of songs in the current playlist."
-  (with-temp-buffer
-    (simple-mpc-call-mpc t "playlist")
-    (count-lines (point-min) (point-max))))
-
 (defun simple-mpc-extract-status (type)
   "Return the mpc data corresponding to TYPE of current song. TYPE may be one of the keys of `simple-mpc-status-re-groups'."
   (with-temp-buffer

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -112,17 +112,6 @@ output as a string."
     (simple-mpc-call-mpc t "playlist")
     (count-lines (point-min) (point-max))))
 
-(defun simple-mpc-message-current-volume ()
-  "Return the current volume."
-  ;; Use "%s" as format-string. Otherwise message will
-  ;; interpret the percent symbol in mpc's output as an
-  ;; incomplete format specifier.
-  (message "%s"
-           (with-temp-buffer
-             (simple-mpc-call-mpc t "volume")
-             (delete-char -1)  ;; delete trailing \n
-             (buffer-string))))
-
 (defun simple-mpc-extract-status (type)
   "Return the mpc data corresponding to TYPE of current song. TYPE may be one of the keys of `simple-mpc-status-re-groups'."
   (with-temp-buffer

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 
+(require 'rx)
 (require 'simple-mpc-vars)
 
 (defconst simple-mpc-status-re

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -104,6 +104,14 @@ output as a string."
     (mark-sexp)
     (buffer-substring (mark) (point))))
 
+(defun simple-mpc-repeat-status ()
+  "Return repeat status."
+  (with-temp-buffer
+    (simple-mpc-call-mpc t "status")
+    (search-backward "repeat")
+    (mark-word 2)
+    (buffer-substring (mark) (point))))
+
 (defun simple-mpc-goto-line (line-number)
   "Go to beginning of line LINE-NUMBER.
 

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -87,39 +87,43 @@ output as a string."
      (delete-char -1)  ;; delete trailing \n
      (buffer-string))))
 
+(defmacro simple-mpc-extract-status (&rest args)
+  `(let (start end)
+     (with-temp-buffer (simple-mpc-call-mpc t "status")
+                       ,@args
+                       (buffer-substring start end))))
+
 (defun simple-mpc-current-artist-and-song ()
   "Return the currently playing artist and song."
-  (with-temp-buffer
-    (simple-mpc-call-mpc t "status")
-    (beginning-of-buffer)
-    (buffer-substring (point) (line-end-position))))
+  (simple-mpc-extract-status
+   (beginning-of-buffer)
+   (setq start (point))
+   (setq end (line-end-position))))
 
 (defun simple-mpc-playing-status ()
   "Return either `playing' or `paused'."
-  (with-temp-buffer
-    (simple-mpc-call-mpc t "status")
-    (beginning-of-buffer)
-    (next-line)
-    (forward-sexp)
-    (buffer-substring (line-beginning-position) (point))))
+  (simple-mpc-extract-status
+   (beginning-of-buffer)
+   (next-line)
+   (setq start (point))
+   (forward-sexp)
+   (setq end (point))))
 
 (defun simple-mpc-repeat-status ()
   "Return repeat status."
-  (with-temp-buffer
-    (simple-mpc-call-mpc t "status")
-    (let (start)
-      (search-backward "repeat")
-      (setq start (point))
-      (forward-sexp 2)
-    (buffer-substring start (point))))
+  (simple-mpc-extract-status
+   (search-backward "repeat")
+   (setq start (point))
+   (forward-sexp 2)
+   (setq end (point))))
 
 (defun simple-mpc-song-position ()
   "Return song position."
-  (with-temp-buffer
-    (simple-mpc-call-mpc t "status")
-    (search-backward-regexp " [0-9]+:")
-    (forward-char)
-    (buffer-substring (point) (line-end-position))))
+  (simple-mpc-extract-status
+   (search-backward-regexp " [0-9]+:")
+   (forward-char)
+   (setq start (point))
+   (setq end (line-end-position))))
 
 (defun simple-mpc-goto-line (line-number)
   "Go to beginning of line LINE-NUMBER.

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -51,7 +51,7 @@
    (group "single: " (or "on" "off"))         ; Single status
    (one-or-more blank)
    (group "consume: " (or "on" "off")))       ; Consume status
-  "Regular expression to capture parts of `mpc status'. This regex will not match if `mpd' is not running.")
+  "Regular expression to capture parts of `mpc status'. This regex will not match if `mpd' is not running or if the playlist is empty.")
 
 (defconst simple-mpc-status-re-groups
   '((artist-song       . 1)

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -95,6 +95,15 @@ output as a string."
     (end-of-line)
     (buffer-substring (point-min) (point))))
 
+(defun simple-mpc-playing-status ()
+  "Return either `playing' or `paused'."
+  (with-temp-buffer
+    (simple-mpc-call-mpc t "status")
+    (beginning-of-buffer)
+    (next-line)
+    (mark-sexp)
+    (buffer-substring (mark) (point))))
+
 (defun simple-mpc-goto-line (line-number)
   "Go to beginning of line LINE-NUMBER.
 

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -112,6 +112,16 @@ output as a string."
     (mark-word 2)
     (buffer-substring (mark) (point))))
 
+(defun simple-mpc-song-position ()
+  "Return song position."
+  (with-temp-buffer
+    (simple-mpc-call-mpc t "status")
+    (search-backward-regexp " [0-9:]+/")
+    (forward-char)
+    (push-mark)
+    (end-of-line)
+    (buffer-substring (point) (mark))))
+
 (defun simple-mpc-goto-line (line-number)
   "Go to beginning of line LINE-NUMBER.
 

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -100,12 +100,6 @@ output as a string."
     (simple-mpc-call-mpc t mpc-args)
     (buffer-string)))
 
-(defun simple-mpc-get-current-playlist-position ()
-  "Return the position, as a number, of the current song."
-  (with-temp-buffer
-    (simple-mpc-call-mpc t '("current" "-f" "%position%"))
-    (string-to-number (buffer-string))))
-
 (defun simple-mpc-get-amount-of-songs-in-playlist ()
   "Return the number of songs in the current playlist."
   (with-temp-buffer

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -2,6 +2,7 @@
 ;;
 ;; Copyright (C) 2015,2016 Joren Van Onder <joren@jvo.sh>
 ;; Copyright (C) 2020 Sean Farley <sean@farley.io>
+;; Copyright (C) 2022 Joseph Turner <joseph@breatheoutbreathe.in>
 
 ;; Author: Joren Van Onder <joren@jvo.sh>
 ;; Maintainer: Joren Van Onder <joren@jvo.sh>
@@ -85,6 +86,14 @@ output as a string."
      (simple-mpc-call-mpc t "volume")
      (delete-char -1)  ;; delete trailing \n
      (buffer-string))))
+
+(defun simple-mpc-current-artist-and-song ()
+  "Return the currently playing artist and song."
+  (with-temp-buffer
+    (simple-mpc-call-mpc t "status")
+    (beginning-of-buffer)
+    (end-of-line)
+    (buffer-substring (point-min) (point))))
 
 (defun simple-mpc-goto-line (line-number)
   "Go to beginning of line LINE-NUMBER.

--- a/simple-mpc-utils.el
+++ b/simple-mpc-utils.el
@@ -92,8 +92,7 @@ output as a string."
   (with-temp-buffer
     (simple-mpc-call-mpc t "status")
     (beginning-of-buffer)
-    (end-of-line)
-    (buffer-substring (point-min) (point))))
+    (buffer-substring (point) (line-end-position))))
 
 (defun simple-mpc-playing-status ()
   "Return either `playing' or `paused'."
@@ -101,26 +100,26 @@ output as a string."
     (simple-mpc-call-mpc t "status")
     (beginning-of-buffer)
     (next-line)
-    (mark-sexp)
-    (buffer-substring (mark) (point))))
+    (forward-sexp)
+    (buffer-substring (line-beginning-position) (point))))
 
 (defun simple-mpc-repeat-status ()
   "Return repeat status."
   (with-temp-buffer
     (simple-mpc-call-mpc t "status")
-    (search-backward "repeat")
-    (mark-word 2)
-    (buffer-substring (mark) (point))))
+    (let (start)
+      (search-backward "repeat")
+      (setq start (point))
+      (forward-sexp 2)
+    (buffer-substring start (point))))
 
 (defun simple-mpc-song-position ()
   "Return song position."
   (with-temp-buffer
     (simple-mpc-call-mpc t "status")
-    (search-backward-regexp " [0-9:]+/")
+    (search-backward-regexp " [0-9]+:")
     (forward-char)
-    (push-mark)
-    (end-of-line)
-    (buffer-substring (point) (mark))))
+    (buffer-substring (point) (line-end-position))))
 
 (defun simple-mpc-goto-line (line-number)
   "Go to beginning of line LINE-NUMBER.

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -101,7 +101,7 @@
   "Helper function to adjust volume by VOLUME-CHANGE."
   (let ((volume-change-string (simple-mpc-convert-number-to-relative-string volume-change)))
     (simple-mpc-call-mpc nil (list "volume" volume-change-string)))
-  (simple-mpc-message-current-volume))
+  (message "%s" (simple-mpc-extract-status 'volume)))
 
 (defun simple-mpc-clear-current-playlist ()
   "Clear the current playlist."

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -73,12 +73,14 @@
 (defun simple-mpc-seek-forward ()
   "Does a relative seek forward by `simple-mpc-seek-time-in-s' seconds."
   (interactive)
-  (simple-mpc-seek-internal simple-mpc-seek-time-in-s))
+  (simple-mpc-seek-internal simple-mpc-seek-time-in-s)
+  (message "%s" (concat (simple-mpc-song-position) " " (simple-mpc-current-artist-and-song))))
 
 (defun simple-mpc-seek-backward ()
   "Does a relative seek backward by -`simple-mpc-seek-time-in-s' seconds."
   (interactive)
-  (simple-mpc-seek-internal (- simple-mpc-seek-time-in-s)))
+  (simple-mpc-seek-internal (- simple-mpc-seek-time-in-s))
+  (message "%s" (concat (simple-mpc-song-position) " " (simple-mpc-current-artist-and-song))))
 
 (defun simple-mpc-seek-internal (time-in-seconds)
   "Seek current song by TIME-IN-SECONDS."

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -60,13 +60,15 @@
   "Play the next song."
   (interactive)
   (simple-mpc-call-mpc nil "next")
-  (simple-mpc-maybe-refresh-playlist t))
+  (simple-mpc-maybe-refresh-playlist t)
+  (message "%s" (simple-mpc-current-artist-and-song)))
 
 (defun simple-mpc-prev ()
   "Play the previous song."
   (interactive)
   (simple-mpc-call-mpc nil "prev")
-  (simple-mpc-maybe-refresh-playlist t))
+  (simple-mpc-maybe-refresh-playlist t)
+  (message "%s" (simple-mpc-current-artist-and-song)))
 
 (defun simple-mpc-seek-forward ()
   "Does a relative seek forward by `simple-mpc-seek-time-in-s' seconds."

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -53,7 +53,8 @@
 (defun simple-mpc-toggle ()
   "Toggle the playing / pause state."
   (interactive)
-  (simple-mpc-call-mpc nil "toggle"))
+  (simple-mpc-call-mpc nil "toggle")
+  (message "%s" (concat (simple-mpc-playing-status) " " (simple-mpc-current-artist-and-song))))
 
 (defun simple-mpc-next ()
   "Play the next song."

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -54,33 +54,33 @@
   "Toggle the playing / pause state."
   (interactive)
   (simple-mpc-call-mpc nil "toggle")
-  (message "%s" (concat (simple-mpc-playing-status) " " (simple-mpc-current-artist-and-song))))
+  (message "%s" (concat (simple-mpc-extract-status 'playing-paused) " " (simple-mpc-extract-status 'artist-song))))
 
 (defun simple-mpc-next ()
   "Play the next song."
   (interactive)
   (simple-mpc-call-mpc nil "next")
   (simple-mpc-maybe-refresh-playlist t)
-  (message "%s" (simple-mpc-current-artist-and-song)))
+  (message "%s" (simple-mpc-extract-status 'artist-song)))
 
 (defun simple-mpc-prev ()
   "Play the previous song."
   (interactive)
   (simple-mpc-call-mpc nil "prev")
   (simple-mpc-maybe-refresh-playlist t)
-  (message "%s" (simple-mpc-current-artist-and-song)))
+  (message "%s" (simple-mpc-extract-status 'artist-song)))
 
 (defun simple-mpc-seek-forward ()
   "Does a relative seek forward by `simple-mpc-seek-time-in-s' seconds."
   (interactive)
   (simple-mpc-seek-internal simple-mpc-seek-time-in-s)
-  (message "%s" (concat (simple-mpc-song-position) " " (simple-mpc-current-artist-and-song))))
+  (message "%s" (concat (simple-mpc-extract-status 'song-position) " " (simple-mpc-extract-status 'artist-song))))
 
 (defun simple-mpc-seek-backward ()
   "Does a relative seek backward by -`simple-mpc-seek-time-in-s' seconds."
   (interactive)
   (simple-mpc-seek-internal (- simple-mpc-seek-time-in-s))
-  (message "%s" (concat (simple-mpc-song-position) " " (simple-mpc-current-artist-and-song))))
+  (message "%s" (concat (simple-mpc-extract-status 'song-position) " " (simple-mpc-extract-status 'artist-song))))
 
 (defun simple-mpc-seek-internal (time-in-seconds)
   "Seek current song by TIME-IN-SECONDS."
@@ -114,7 +114,7 @@
   "Toggle repeat mode."
   (interactive)
   (simple-mpc-call-mpc nil "repeat")
-  (message "%s" (simple-mpc-repeat-status)))
+  (message "%s" (simple-mpc-extract-status 'repeat)))
 
 (defun simple-mpc-shuffle-current-playlist ()
   "Shuffle the current playlist."

--- a/simple-mpc.el
+++ b/simple-mpc.el
@@ -112,7 +112,7 @@
   "Toggle repeat mode."
   (interactive)
   (simple-mpc-call-mpc nil "repeat")
-  (message "%s" "Toggled repeat mode."))
+  (message "%s" (simple-mpc-repeat-status)))
 
 (defun simple-mpc-shuffle-current-playlist ()
   "Shuffle the current playlist."


### PR DESCRIPTION
Add helper functions to extract specific pieces of information from `mpc status` in a hacky way. Echo the extracted information on relevant commands.

Also, display mpc status in the simple-mpc buffer. This functionality could be improved, since it only updated when the buffer is reverted (by pressing `g` or calling `simple-mpc` again). Functions which changes the status, e.g., `simple-mpc-toggle`, do not update the buffer.